### PR TITLE
Create a page with direct links to development builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 public/
+*.swp

--- a/content/downloads/devel/index.md
+++ b/content/downloads/devel/index.md
@@ -3,14 +3,57 @@ title = "Development builds"
 template = "devel-builds.html"
 +++
 
-## Linux
+## Installation notes
 
-TODO: list dependencies
+Development snapshot builds do not touch configuration of stable
+version; they use separate config file (`dosbox-staging-git.conf`)
+located in:
 
-## Windows
+<table>
+  <tr>
+    <td>Linux</td>
+    <td><code>~/.config/dosbox/</code></td>
+  </tr>
+  <tr>
+    <td>Windows</td>
+    <td><code>C:\Users\USERNAME\AppData\Local\DOSBox\</code></td>
+  </tr>
+  <tr>
+    <td>macOS</td>
+    <td><code>~/Library/Preferences/DOSBox/</code></td>
+  </tr>
+</table>
 
-TODO: link to info
 
-## macOS
+### Linux
 
-TODO: link to info
+These are dynamically-linked x86\_64 builds, you'll need additional packages installed via your package manager.
+
+#### Fedora
+
+    sudo dnf install SDL2 SDL2_net opusfile
+
+#### Debian, Ubuntu
+
+    sudo apt install libsdl2-2.0-0 libsdl2-net-2.0-0 libopusfile0
+
+#### Arch, Manjaro
+
+    sudo pacman -S sdl2 sdl2_net opusfile
+
+
+### Windows
+
+Windows executables in a snapshot packages are not signed, therefore Windows 10
+might prevent the program from starting.
+
+See [this guide](/downloads/windows/#ms-ss) to learn how to deal with this.
+
+
+### macOS
+
+macOS bundle is notarized via Apple Gatekeeper, your OS will try to prevent
+dosbox-staging from running.
+
+See [this guide](/downloads/macos/#apple-gatekeeper) to learn how to deal with
+this.

--- a/content/downloads/devel/index.md
+++ b/content/downloads/devel/index.md
@@ -1,0 +1,16 @@
++++
+title = "Development builds"
+template = "devel-builds.html"
++++
+
+## Linux
+
+TODO: list dependencies
+
+## Windows
+
+TODO: link to info
+
+## macOS
+
+TODO: link to info

--- a/content/downloads/devel/index.md
+++ b/content/downloads/devel/index.md
@@ -5,9 +5,8 @@ template = "devel-builds.html"
 
 ## Installation notes
 
-Development snapshot builds do not touch configuration of stable
-version; they use separate config file (`dosbox-staging-git.conf`)
-located in:
+Development snapshots use a separate configuration file named<br/>
+`dosbox-staging-git.conf`, located alongside the stable conf file in:
 
 <table>
   <tr>

--- a/templates/devel-builds.html
+++ b/templates/devel-builds.html
@@ -81,7 +81,15 @@ document.addEventListener("DOMContentLoaded", () => {
     <h1 class="post-title">{{ page.title }}</h1>
 
     <p>
-        <em>Development build artifacts are hosted on GitHub; you need to be logged in to download them.</em>
+        These are unstable development snapshots intended for testing and
+	showcasing new features; if you want to download a stable build,
+	head on to <a href="/downloads/linux/">Linux</a>,
+	<a href="/downloads/windows/">Windows</a>, or
+	<a href="/downloads/macos/">macOS</a> download pages.
+    </p>
+
+    <p>
+        <em>Build artifacts are hosted on GitHub; you need to be logged in to download them.</em>
     </p>
 
     <table>

--- a/templates/devel-builds.html
+++ b/templates/devel-builds.html
@@ -81,28 +81,31 @@ document.addEventListener("DOMContentLoaded", () => {
     <h1 class="post-title">{{ page.title }}</h1>
 
     <p>
-        <em>Development build artefacts are hosted on GitHub; you need to be logged in to download them.</em>
+        <em>Development build artifacts are hosted on GitHub; you need to be logged in to download them.</em>
     </p>
 
-    <div>
-        <a id="linux-build-link">Linux</a>
-        <span id="linux-build-version">-</span>
-        <span id="linux-build-date">-</span>
-    </div>
-
-    <div>
-        <a id="windows-build-link">Windows</a>
-        <span id="windows-build-version">-</span>
-        <span id="windows-build-date">-</span>
-    </div>
-
-    <div>
-        <a id="macos-build-link">macOS</a>
-        <span id="macos-build-version">-</span>
-        <span id="macos-build-date">-</span>
-    </div>
-
-    </p>
+    <table>
+       <tr>
+          <th>Download link</th>
+          <th>Build version</th>
+          <th>Date</th>
+       </tr>
+       <tr>
+          <td><a id="linux-build-link">Linux</a></td>
+          <td id="linux-build-version">-</td>
+          <td id="linux-build-date">-</td>
+       </tr>
+       <tr>
+          <td><a id="windows-build-link">Windows</a></td>
+          <td id="windows-build-version">-</td>
+          <td id="windows-build-date">-</td>
+       </tr>
+       <tr>
+          <td><a id="macos-build-link">macOS</a></td>
+          <td id="macos-build-version">-</td>
+          <td id="macos-build-date">-</td>
+       </tr>
+    </table>
 
     {{ page.content | safe }}
 </div>

--- a/templates/devel-builds.html
+++ b/templates/devel-builds.html
@@ -1,0 +1,78 @@
+{% extends "content_with_footer.html" %}
+
+{% block extra_js %}
+<script>
+<!--
+
+// Fetch build status using GitHub API and update HTML
+function set_ci_status(workflow_file, os_name) {
+    let gh_api_url = "https://api.github.com/repos/dosbox-staging/dosbox-staging/";
+    fetch(gh_api_url + "actions/workflows/" + workflow_file + "/runs")
+        .then(response => {
+
+            // Handle HTTP error
+            if (response.status !== 200) {
+                console.log("Looks like there was a problem." +
+                    "Status Code: " + response.status);
+                return;
+            }
+
+            // Examine the text in the response
+            response.json().then(data => {
+
+                let status = data.workflow_runs
+                    .filter(run => run.head_branch == "master")
+                    .find(run => run.conclusion == "success");
+                // console.log(status);
+
+                let build_link = document.getElementById(os_name + "-build-link");
+                build_link.setAttribute("href", status.html_url);
+
+                let build_date = new Date(status.updated_at);
+                let date_span = document.getElementById(os_name + "-build-date");
+                date_span.textContent = build_date.toUTCString();
+            });
+        })
+        .catch(err => {
+            console.log('Fetch Error :-S', err);
+        });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    set_ci_status("linux.yml", "linux");
+    set_ci_status("windows.yml", "windows");
+    set_ci_status("macos.yml", "macos");
+});
+
+-->
+</script>
+{% endblock extra_js %}
+
+{% block page_content %}
+<div class="post">
+    <h1 class="post-title">{{ page.title }}</h1>
+
+    <p>
+        <em>Development build artefacts are hosted on GitHub; you need to be logged in to download them.</em>
+    </p>
+
+    <div>
+        <a id="linux-build-link">Linux</a>
+        <span id="linux-build-date">N/A</span>
+    </div>
+
+    <div>
+        <a id="windows-build-link">Windows</a>
+        <span id="windows-build-date">N/A</span>
+    </div>
+
+    <div>
+        <a id="macos-build-link">macOS</a>
+        <span id="macos-build-date">N/A</span>
+    </div>
+
+    </p>
+
+    {{ page.content | safe }}
+</div>
+{% endblock page_content %}

--- a/templates/devel-builds.html
+++ b/templates/devel-builds.html
@@ -4,6 +4,32 @@
 <script>
 <!--
 
+function set_build_version(gh_api_artifacts, os_name) {
+    fetch(gh_api_artifacts)
+        .then(response => {
+            if (response.status !== 200)
+                return;
+
+            response.json().then(data => {
+                let changelog = data.artifacts
+                    .find(a => a.name.startsWith("changelog-"));
+
+                if (changelog === undefined)
+                    return;
+
+                //console.log(changelog);
+
+                let n = changelog.name.length;
+                let version = changelog.name.substring(10, n - 4);
+                let version_el = document.getElementById(os_name + "-build-version");
+                version_el.textContent = version;
+            });
+        })
+        .catch(err => {
+            console.log('Fetch Error :-S', err);
+        });
+}
+
 // Fetch build status using GitHub API and update HTML
 function set_ci_status(workflow_file, os_name) {
     let gh_api_url = "https://api.github.com/repos/dosbox-staging/dosbox-staging/";
@@ -29,8 +55,10 @@ function set_ci_status(workflow_file, os_name) {
                 build_link.setAttribute("href", status.html_url);
 
                 let build_date = new Date(status.updated_at);
-                let date_span = document.getElementById(os_name + "-build-date");
-                date_span.textContent = build_date.toUTCString();
+                let date_el = document.getElementById(os_name + "-build-date");
+                date_el.textContent = build_date.toUTCString();
+
+                set_build_version(status.artifacts_url, os_name);
             });
         })
         .catch(err => {
@@ -58,17 +86,20 @@ document.addEventListener("DOMContentLoaded", () => {
 
     <div>
         <a id="linux-build-link">Linux</a>
-        <span id="linux-build-date">N/A</span>
+        <span id="linux-build-version">-</span>
+        <span id="linux-build-date">-</span>
     </div>
 
     <div>
         <a id="windows-build-link">Windows</a>
-        <span id="windows-build-date">N/A</span>
+        <span id="windows-build-version">-</span>
+        <span id="windows-build-date">-</span>
     </div>
 
     <div>
         <a id="macos-build-link">macOS</a>
-        <span id="macos-build-date">N/A</span>
+        <span id="macos-build-version">-</span>
+        <span id="macos-build-date">-</span>
     </div>
 
     </p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,9 @@
       .youtube > iframe { width: 640px; height: 350px; }
       -->
       </style>
+
+{% block extra_js %}
+{% endblock %}
 {% endblock %}
 
 {% block sidebar_about %}


### PR DESCRIPTION
Using GitHub v3 REST API: https://docs.github.com/en/rest/reference/actions

I haven't touched javascript in years, so my JS skills probably suck, but it works ;)

After merge, this will create a new page: in http://dosbox-staging.github.io/downloads/devel/ ; download links point directly to Artifact download page for the latest successful build from master branch for given OS. The page will be "hidden" for now (not linked anywhere), until it will be filled with content.

There's a tiny implementation detail, that I don't want to deal with ATM (but will need to deal with it soon): GH API will paginate build statuses 30 per OS; therefore if we'll have more than 30 builds (any branches) between two merges to master, the links will be broken.