### PR TITLE
Update the vision for 2022

### DIFF
--- a/content/about/index.md
+++ b/content/about/index.md
@@ -1,40 +1,41 @@
 +++
 title = "Vision"
 template = "about.html"
-date = 2020-04-21
+date = 2022-03-26
 +++
 
-**DOSBox Staging** is an attempt to revitalize DOSBox's development process.
-It's not a rewrite, but a continuation and improvement on the existing DOSBox
-codebase while leveraging modern development tools and practices.
+**DOSBox Staging** is an attempt to revitalize DOSBox's development process
+by applying modern development practices to the existing DOSBox codebase.
 
 ## Goals
 
 - Improve the **out-of-the-box** experience for new users.
 - Encourage **new contributors** by removing barriers to entry.
-- Fix, cleanup, and integrate several notable **community-developed
-  patches** that are not included in the SourceForge-hosted project.
 - Implement **new features** and quality-of-life improvements.
-- Prioritize **DOS gaming**, while welcoming general improvements (such as for
-  productivity software) that don't impact game emulation quality or
-  code-maintainability.
-- Strike a balance between emulation **quality**, **speed**, and **usability**.
+- Fix, cleanup, and integrate notable **community-developed patches** that
+  fill valuable general-purpose and/or gaming-focused emulation holes
+  (provided they don't impact broader compatibility, performance, stability,
+  or code maintainability).
+- Prioritize the **quality** of newly written code to minimize technical
+  debt and ease future maintenance, which generally means
+  following the [Staging Coding Style Guide](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#coding-style) 
+  and being aware of best practices, like the [C++ Core Guidelines](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines).
 - Deliver a consistent cross-platform experience.
-- Leverage ongoing DOSBox development.
+- Leverage upstream and community developments in DOSBox.
 - Focus on supporting up-to-date, current Operating Systems and modern
-  hardware.
+ hardware.
 
 A summary of technical and feature differences is
 [here](https://github.com/dosbox-staging/dosbox-staging#summary-of-differences-compared-to-upstream).
 
-Planned features are recorded in
+We plan to add the features listed in
 [the backlog](https://github.com/dosbox-staging/dosbox-staging/projects/3).
 
 ## Non-goals
 
-- Supporting old platforms such as Windows 9x, OS/2, and Mac OS X 10.4
-  (and earlier).  If you want to run DOSBox on retro platforms, then
-  your best bet is to use [DOSBox](https://www.dosbox.com/).
+- Supporting old operating systems (Windows 9x, OS/2, and Mac OS X 10.4)
+  and limited CPU/memory hardware, which are constraints [DOSBox](https://www.dosbox.com/)
+  continues to support.
 
 - Perfecting DOS-era hardware emulation. The
   [PCem](https://pcem-emulator.co.uk/) and
@@ -42,12 +43,10 @@ Planned features are recorded in
   this goal.
 
 - Being the fastest DOS emulator on x86 hardware. Users interested in
-  emulation speed should look at
-  [dosemu2](https://github.com/dosemu2/dosemu2).
+  emulation speed should look at [dosemu2](https://github.com/dosemu2/dosemu2).
 
 - Acting as a general-purpose DOS operating system. For that, there's
   [FreeDOS](https://www.freedos.org/).
-
 
 ## Relationship to DOSBox
 


### PR DESCRIPTION
One of Staging's stated goals is to encourage new contributors by removing barriers to entry.

One of these barriers was in fact Staging's constrained gaming-specific wording. To keep with our goal of growing the team, this commit puts general purpose and gaming-focussed emulation improvements on equal
footing with a new caveat being that the changes (in either case) need to be valuable.

Previously we were using gaming as a substitute for "value", meaning that if one or more games use a given emulation feature, then that feature could be deemed valuable. This new change means we can assess the value or merit of filling an emulation hole given the broader context of the value it brings to users.

This commit also tightens up the wording in a couple of other areas (but keeps the same meaning and intent).