### PR TITLE
Fixes piping descriptions and section titles

### DIFF
--- a/content/v0.79.0.md
+++ b/content/v0.79.0.md
@@ -18,7 +18,7 @@ date = 2022-09-19
 	* 3.7. ["One OPL mode to rule them all" &#128141;](#OneOPLmodetorulethemall128141)
 	* 3.8. [FluidSynth Configuration Changes](#FluidSynthConfigurationChanges)
 	* 3.9. [ripa's PC speaker Patch](#ripasPCspeakerPatch)
-	* 3.10. [Parallel Port DAC Models: Disney, Covox, and Stereo-On-1](#ParallelPortDACModels:DisneyCovoxandStereo-On-1)
+	* 3.10. [Parallel Port DAC Models: Disney, Covox, and Stereo-On-1](#ParallelPortDACModels-DisneyCovoxandStereo-On-1)
 	* 3.11. [Audio Mute and Pause](#AudioMuteandPause)
 * 4. [Graphical Improvements](#GraphicalImprovements)
 	* 4.1. [Shader Reload Shortcut](#ShaderReloadShortcut)
@@ -50,7 +50,7 @@ date = 2022-09-19
 	* 9.1. [Command-line Setting of Conf Options](#Command-lineSettingofConfOptions)
 	* 9.2. [Windows Installer for Windows Users](#WindowsInstallerforWindowsUsers)
 	* 9.3. [Configurable Modem Connect Speeds](#ConfigurableModemConnectSpeeds)
-	* 9.4. [Handling Options for Memory Faults in Buggy Gams](#HandlingOptionsforMemoryFaultsinBuggyGams)
+	* 9.4. [Handling Options for Memory Faults in Buggy Games](#HandlingOptionsforMemoryFaultsinBuggyGames)
 * 10. [Developer-related Improvements](#Developer-relatedImprovements)
 	* 10.1. [Self-Documenting Bit Twiddling with `bit_view`](#Self-DocumentingBitTwiddlingwithbit_view)
 	* 10.2. [Memory Block and Type Size Simplification](#MemoryBlockandTypeSizeSimplification)
@@ -283,7 +283,7 @@ pcspeaker = discrete
 
 Note: There are some audible regressions and harmonics that still exist in some games, so that's why this is an alternative and not the default.
 
-###  3.10. <a name='ParallelPortDACModels:DisneyCovoxandStereo-On-1'></a>Parallel Port DAC Models: Disney, Covox, and Stereo-On-1
+###  3.10. <a name='ParallelPortDACModels-DisneyCovoxandStereo-On-1'></a>Parallel Port DAC Models: Disney, Covox, and Stereo-On-1
 
 Those familiar with DOSBox know that these three devices are emulated with the universal `disney = true` setting.
 
@@ -436,7 +436,7 @@ dos_rate = default | host | custom-rate
 
 ###  5.1. <a name='PipingfromtheDOSPromptorBatchFiles'></a>Piping from the DOS Prompt or Batch Files
 
-DOSBox did not support the piping operation previously, but DOSBox Staging now brings piping support as how it has worked in DOS and most other operating systems. This allows two or more commands to communicate by passing the output text of one command to another as its input text. For example, commands like `TYPE FILE.TXT | MORE` will work, so that you will be able to display the content of `FILE.TXT` one screen at a time, Multiple piping is also supported, such as `DIR | SORT | MORE` for displaying sorted directory output one screen at a time.
+DOSBox did not support the piping operation previously, but DOSBox Staging now brings piping support as how it has worked in DOS and most other operating systems. This allows two or more commands to communicate by passing the output text of one command to another as its input text. For example, commands like `ECHO Y | CHOICE` will work, so that the `Y` option will be passed as the input of `CHOICE` command. Chained piping is also supported, such as `DIR | SORT | MORE` for displaying sorted directory output one screen at a time (provided that you have the `SORT` and `MORE` commands from MS-DOS or FreeDOS in your path). If the current directory and `C:\` are both read-only, the environment variable `%TEMP%` (or `%TMP%`) needs to be set within DOS pointing to a writable directory so that piping will work properly (e.g. `SET TEMP=C:\TEMP`).
 
 ###  5.2. <a name='FileAttributeSupportandATTRIBCommand'></a>File Attribute Support and ATTRIB Command
 
@@ -612,7 +612,7 @@ serial1 = modem baudrate:2400
 
 Although this doesn't change the underlying baud rate, it can help satisfy old modem software if it's unable to handle (or parse) the larger connect values.
 
-###  9.4. <a name='HandlingOptionsforMemoryFaultsinBuggyGams'></a>Handling Options for Memory Faults in Buggy Gams
+###  9.4. <a name='HandlingOptionsforMemoryFaultsinBuggyGames'></a>Handling Options for Memory Faults in Buggy Games
 
 Extremely rare programming bugs :smirk: in some DOS games (and programs) may cause them to accidentally write data beyond their allocated memory region, similar to "painting outside the lines". DOSBox is great at catching these instances: it flags the corruption and quits, preventing the program from barreling on and possibly doing more harm such as writing corrupt save games, documents, and so on.
 


### PR DESCRIPTION
This fixes the descriptions of the piping operation as discussed earlier, and also fixes section titles/links for "#HandlingOptionsforMemoryFaultsinBuggyGames" and "#ParallelPortDACModels-DisneyCovoxandStereo-On-1".