### PR TITLE
Fix image link to the "Earthworm Jim (synced CFR)" screenshot

### DIFF
--- a/content/v0.79.0.md
+++ b/content/v0.79.0.md
@@ -421,7 +421,7 @@ In addition to VFR, DOSBox Staging supports a **Constant Frame Rate** (CFR) pres
 
 By default, DOSBox Staging inspects runtime conditions and picks the optimal presentation mode.
 
-[![Earthworm Jim (synced CFR)](/synced_cfr_ewj.png)](/zsynced_cfr_ewj.png)
+[![Earthworm Jim (synced CFR)](/synced_cfr_ewj.png)](/synced_cfr_ewj.png)
 
 _Synced CFR mode selected due to vsync-enforced video drivers_
 


### PR DESCRIPTION
The image for the "Earthworm Jim (synced CFR)" screenshot appeared to link incorrectly, resulting a "404: Page not found" issue when a user clicks the image. This PR fixes the bug.