### PR TITLE
WinXP added to the unsupported host OS list

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -389,7 +389,7 @@ backlog</a>.</p>
 <h2 id="non-goals">Non-goals<a class="headerlink" href="#non-goals" title="Permanent link">¶</a></h2>
 <ul>
 <li>
-<p>Support old operating systems (Windows 9x/Me, OS/2, and Mac OS X 10.4)
+<p>Support old operating systems (Windows 9x/Me/XP, OS/2, and Mac OS X 10.4)
   and limited CPU/memory hardware, which are constraints
   <a href="https://www.dosbox.com/">DOSBox</a> continues to support.</p>
 </li>


### PR DESCRIPTION
Per [0.75 release notes](https://dosbox-staging.github.io/downloads/release-notes/0.75.0/):
> DOSBox Staging does not run on Windows XP or earlier Windows versions.

Current [About](https://dosbox-staging.github.io/about/#non-goals) text:
> Non-goals
> - Support old operating systems (Windows 9x/Me, OS/2, and Mac OS X 10.4) and limited CPU/memory hardware, which are constraints [DOSBox](https://www.dosbox.com/) continues to support.

This PR adds in that bullet "/XP": 
- Support old operating systems (Windows 9x/Me/**XP**, OS/2, and Mac OS X 10.4)...

Two questions:
- "limited CPU/memory" is not supported, but what is actually the limit/requirement? By reading the OS list I infer 800MHz/384MB, the minimum requirement for Vista (which is lower than the minimum for Mac OS X 10.5). Should that be mentioned?
- [DOSBox original](https://www.dosbox.com/download.php?main=1) lists also FreeBSD, RISC OS, Solaris, BeOS - most of those are still maintained in one way or another, so I'm not sure they can be considered "old operating system". Should those be listed in a separate bullet?

One observation:
- Would be nice (and responsible preservation-wise) if a host OS is not supported anymore, then the same OS is supported as guest. I know it's out of scope now, but would like to see Win9x and stretching even further even OS/2 and WinXP as guests.