### PR TITLE
Explanation for Vista, Win7, 32-bit Windows

### DIFF
--- a/downloads/development-builds/index.html
+++ b/downloads/development-builds/index.html
@@ -513,8 +513,8 @@ function set_ci_status(workflow_file, os_name, description, page = 1) {
 document.addEventListener("DOMContentLoaded", () => {
     set_ci_status("linux.yml", "linux", "Linux");
     set_ci_status("macos.yml", "macos", "macOS");
-    set_ci_status("windows-msys2.yml", "msys2", "Windows MSYS2 builds");
-    set_ci_status("windows-msvc.yml", "windows", "Windows MSVC builds");
+    set_ci_status("windows-msys2.yml", "msys2", "Windows MSYS2 builds (64-bit ZIP, 64-bit Installer with MSYS2 and MSVC)");
+    set_ci_status("windows-msvc.yml", "windows", "Windows MSVC builds (32-bit ZIP, 64-bit ZIP)");
 });
 
 </script>

--- a/downloads/macos/index.html
+++ b/downloads/macos/index.html
@@ -441,7 +441,7 @@ brew install dosbox-staging
 </code></pre></div>
 <h2 id="macports">MacPorts<a class="headerlink" href="#macports" title="Permanent link">¶</a></h2>
 <p>The <a href="https://ports.macports.org/port/dosbox-staging/">MacPorts package</a>
-should build on systems as old as macOS 10.7 (Lion, circa 2011) or newer.
+should build on systems as old as macOS 10.6 (Snow Leopard, circa 2009) or newer.
 Learn how to setup MacPorts <a href="https://guide.macports.org/">here</a>.</p>
 <div class="highlight"><pre><span></span><code>sudo port selfupdate
 sudo port install dosbox-staging

--- a/downloads/windows/index.html
+++ b/downloads/windows/index.html
@@ -439,6 +439,11 @@ sha256: 3680cbdf7a91467877b51c95e468ef45<wbr/>b186b42518c3163fab85c727923ee659
 </small></p>
 <p>Check out the <a href="../release-notes/0.80.1/">0.80.1 release notes</a> to learn about
 the changes and improvements introduced by this release.</p>
+<p>For 32-bit Windows 7 and later, and for 64-bit Windows 7 hosts use the MSVC <a class="headerlink" href="#development-snapshot-builds" title="Development snapshot builds">snapshot builds</a>.
+The 64-bit MSVC build on Windows 7 and later also can be optionally selected in the installer.</p>
+<p>Windows Vista hosts are supported out-of-the-box up to release 0.78.1. 
+Subsequent releases can be <a href="https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/build-windows.md#build-using-msys2">build from source</a> by excluding FluidSynth (MIDI) and Slirp (NE2000) via:
+MSYS2 Clang build with step 8 command "<small>meson setup -Duse_fluidsynth=false -Duse_slirp=false build/release-clang --native-file=.github/meson/native-clang.ini</small>"</p>
 <div class="admonition important">
 <p class="admonition-title">Important</p>
 <p>If Windows 8.x or Windows 10 prevents you from running DOSBox Staging via

--- a/downloads/windows/index.html
+++ b/downloads/windows/index.html
@@ -439,8 +439,8 @@ sha256: 3680cbdf7a91467877b51c95e468ef45<wbr/>b186b42518c3163fab85c727923ee659
 </small></p>
 <p>Check out the <a href="../release-notes/0.80.1/">0.80.1 release notes</a> to learn about
 the changes and improvements introduced by this release.</p>
-<p>For 32-bit Windows 7 and later, and for 64-bit Windows 7 hosts use the MSVC <a class="headerlink" href="#development-snapshot-builds" title="Development snapshot builds">snapshot builds</a>.
-The 64-bit MSVC build on Windows 7 and later also can be optionally selected in the installer.</p>
+<p>For 32-bit Windows 7 and newer, and for 64-bit Windows 7 hosts use the MSVC <a class="headerlink" href="#development-snapshot-builds" title="Development snapshot builds">snapshot builds</a>.
+The 64-bit MSVC build on Windows 7 and newer also can be optionally selected in the installer.</p>
 <p>Windows Vista hosts are supported out-of-the-box up to release 0.78.1. 
 Subsequent releases can be <a href="https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/build-windows.md#build-using-msys2">build from source</a> by excluding FluidSynth (MIDI) and Slirp (NE2000) via:
 MSYS2 Clang build with step 8 command "<small>meson setup -Duse_fluidsynth=false -Duse_slirp=false build/release-clang --native-file=.github/meson/native-clang.ini</small>"</p>
@@ -486,147 +486,147 @@ command-line install parameters, please see <a href="https://jrsoftware.org/ishe
 <h2 id="older-builds">Older builds<a class="headerlink" href="#older-builds" title="Permanent link">¶</a></h2>
 <ul>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.0/dosbox-staging-v0.80.0-setup.exe">DOSBox Staging 0.80.0 64-bit (Installer)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.0/dosbox-staging-v0.80.0-setup.exe">DOSBox Staging 0.80.0 64-bit (Installer)</a> (Windows 7 or newer)
 <br/>
 <small>
   sha256: 84445c869e58f6b4591484f6178c7b5b<wbr/>3c8f284bf9460e9afc4502ba842ab039
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.0/dosbox-staging-windows-msys2-x86_64-v0.80.0.zip">DOSBox Staging 0.80.0 64-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.80.0/dosbox-staging-windows-msys2-x86_64-v0.80.0.zip">DOSBox Staging 0.80.0 64-bit (zip)</a> (Windows 7 or newer)
 <br/>
 <small>
   sha256: 075be379ed4475615e0e86953eb21f02<wbr/>4c74b4cafd6914e9cf5ef40e3d9e26cd
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.1/dosbox-staging-v0.79.1-setup.exe">DOSBox Staging 0.79.1 64-bit (installer)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.1/dosbox-staging-v0.79.1-setup.exe">DOSBox Staging 0.79.1 64-bit (installer)</a> (Windows 7 or newer)
 <br/>
 <small>
   sha256: 0045ac995ada0af955681983ae86c969<wbr/>a05030c25173618f8b1547a267046a27
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.1/dosbox-staging-windows-x86_64-v0.79.1.zip">DOSBox Staging 0.79.1 64-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.1/dosbox-staging-windows-x86_64-v0.79.1.zip">DOSBox Staging 0.79.1 64-bit (zip)</a> (Windows 7 or newer)
 <br/>
 <small>
   sha256: 8c7045dfea6dc20bb985cff516d2faee<wbr/>51d2ecaf054db60632857b6941d3d648
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.0/dosbox-staging-v0.79.0-setup.exe">DOSBox Staging 0.79.0 64-bit (installer)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.0/dosbox-staging-v0.79.0-setup.exe">DOSBox Staging 0.79.0 64-bit (installer)</a> (Windows 7 or newer)
 <br/>
 <small>
   sha256: 154c663f76d0ca46d1d23d8c2bcea2d8<wbr/>3717f1ba9103067a6a6f5ce814cf0cb2
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.0/dosbox-staging-windows-x86_64-v0.79.0.zip">DOSBox Staging 0.79.0 64-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.79.0/dosbox-staging-windows-x86_64-v0.79.0.zip">DOSBox Staging 0.79.0 64-bit (zip)</a> (Windows 7 or newer)
 <br/>
 <small>
   sha256: b3633d425489fbb5f6f9b3de75e4c2c6<wbr/>dd0713c3aec504e42cac948cc1550bbe
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.1/dosbox-staging-windows-msys2-x86_64-v0.78.1.zip">DOSBox Staging 0.78.1 64-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.1/dosbox-staging-windows-msys2-x86_64-v0.78.1.zip">DOSBox Staging 0.78.1 64-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: 3c2f408125351154a37e93de8a4bd05d<wbr/>0c722bbf53e1f583909e4ca6c3eb9204
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.1/dosbox-staging-windows-x64-v0.78.1.zip">DOSBox Staging with built-in debugger 0.78.1 64-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.1/dosbox-staging-windows-x64-v0.78.1.zip">DOSBox Staging with built-in debugger 0.78.1 64-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: b99f3c354f831ed2b0ed04d215170f69<wbr/>6b6fc18285b0c7192c0abab62c41bbc8
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.0/dosbox-staging-windows-msys2-x86_64-v0.78.0.zip">DOSBox Staging 0.78.0 64-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.0/dosbox-staging-windows-msys2-x86_64-v0.78.0.zip">DOSBox Staging 0.78.0 64-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: f13cba664259fdb0db5e32826e13dcde<wbr/>d4270557963f6e823a4731129f23a8a3
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.0/dosbox-staging-windows-msys2-i686-v0.78.0.zip">DOSBox Staging 0.78.0 32-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.78.0/dosbox-staging-windows-msys2-i686-v0.78.0.zip">DOSBox Staging 0.78.0 32-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: 0ca9201cdf3f3a1576b97b0de0e87280<wbr/>b75c633976f0b179ba33a68d44f5ba56
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.77.1/dosbox-staging-windows-x64-v0.77.1.zip">DOSBox Staging 0.77.1 64-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.77.1/dosbox-staging-windows-x64-v0.77.1.zip">DOSBox Staging 0.77.1 64-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: 11ba992ece6d3e4ef2046fcdb6d842da<wbr/>364b69720a921d61fdcc793eb52e7051
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.77.1/dosbox-staging-windows-x86-v0.77.1.zip">DOSBox Staging 0.77.1 32-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.77.1/dosbox-staging-windows-x86-v0.77.1.zip">DOSBox Staging 0.77.1 32-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: a34883101486ce2af071a29c6390f203<wbr/>8889fc519e042101284f2a6999d9f0ef
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.77.0/dosbox-staging-windows-x64-v0.77.0.zip">DOSBox Staging 0.77.0 64-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.77.0/dosbox-staging-windows-x64-v0.77.0.zip">DOSBox Staging 0.77.0 64-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: cacdac418642fd8c7faf1e5955110c35<wbr/>d0c207392ae20835707fd2a1e1114b82
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.77.0/dosbox-staging-windows-x86-v0.77.0.zip">DOSBox Staging 0.77.0 32-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.77.0/dosbox-staging-windows-x86-v0.77.0.zip">DOSBox Staging 0.77.0 32-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: f718d07bab69e3e1be0b28207039cea2<wbr/>746c7e45b8ba7a19b625011f477e609a
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.76.0/dosbox-staging-windows-x86-v0.76.0.zip">DOSBox Staging 0.76.0 32-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.76.0/dosbox-staging-windows-x86-v0.76.0.zip">DOSBox Staging 0.76.0 32-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: 646d2f3fa8189e411589fedcb8148a29<wbr/>5361693a6ce95d08e06f4a70e5a36b16
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.75.2/dosbox-staging-windows-x64-v0.75.2.zip">DOSBox Staging 0.75.2 64-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.75.2/dosbox-staging-windows-x64-v0.75.2.zip">DOSBox Staging 0.75.2 64-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: 09f0ca911813a64b8814880eb6e49ad4<wbr/>dcdac9a5bb9263c4887ad82b71fad292
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.75.2/dosbox-staging-windows-x86-v0.75.2.zip">DOSBox Staging 0.75.2 32-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.75.2/dosbox-staging-windows-x86-v0.75.2.zip">DOSBox Staging 0.75.2 32-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: 51dc171ff52ea395c6a22f09ebb98a93<wbr/>974a95c701ca81008368c22a66deced2
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.75.1/dosbox-staging-windows-x64-v0.75.1.zip">DOSBox Staging 0.75.1 64-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.75.1/dosbox-staging-windows-x64-v0.75.1.zip">DOSBox Staging 0.75.1 64-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: 80c60c4377ff2882649f113b3cb3bcd4<wbr/>07c17acaac344c49fa1fc4229813f012
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.75.1/dosbox-staging-windows-x86-v0.75.1.zip">DOSBox Staging 0.75.1 32-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.75.1/dosbox-staging-windows-x86-v0.75.1.zip">DOSBox Staging 0.75.1 32-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: 843c742a348f575862e152e02cf174be<wbr/>0ea1c52bdb6e4bffd65f34af88b566b7
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.75.0/dosbox-staging-windows-v0.75.0.zip">DOSBox Staging 0.75.0 32-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.75.0/dosbox-staging-windows-v0.75.0.zip">DOSBox Staging 0.75.0 32-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: 69046adcef2ef9920fbba8d40fc9e51f<wbr/>3dd144ba4549787e1816cf1c2ae87d71
   </small></p>
 </li>
 <li>
-<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.75.0-rc1/dosbox-staging-windows-v0.75.0-rc1.zip">DOSBox Staging 0.75.0-rc1 32-bit (zip)</a>
+<p><a href="https://github.com/dosbox-staging/dosbox-staging/releases/download/v0.75.0-rc1/dosbox-staging-windows-v0.75.0-rc1.zip">DOSBox Staging 0.75.0-rc1 32-bit (zip)</a> (Vista or newer)
 <br/>
 <small>
   sha256: 738d2ae2101384f2eeaf1895de64cf1b<wbr/>4c76eaf7873de7e15b7f52145dfed7e7


### PR DESCRIPTION
From dosbox-staging/dosbox-staging/issues/2258

Adding in Downloads\Windows:
For 32-bit Windows 7 and later, and for 64-bit Windows 7 hosts use the MSVC <a class="headerlink" href="#development-snapshot-builds" title="Development snapshot builds">snapshot builds</a>.
The 64-bit MSVC build on Windows 7 and later also can be optionally selected in the installer.

Windows Vista hosts are supported out-of-the-box up to release 0.78.1. 
Subsequent releases can be <a href="https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/build-windows.md#build-using-msys2">build from source</a> by excluding FluidSynth (MIDI) and Slirp (NE2000) via:
MSYS2 Clang build with step 8 command "<small>meson setup -Duse_fluidsynth=false -Duse_slirp=false build/release-clang --native-file=.github/meson/native-clang.ini</small>"

Adding in Development builds:
- Windows MSYS2 builds **(64-bit ZIP, 64-bit Installer with MSYS2 and MSVC)**
- Windows MSVC builds **(32-bit ZIP, 64-bit ZIP)**